### PR TITLE
Fix drive deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gdsync
-Google Drive synchronization tool. Successor of the venerable `autosave_gd` (https://github.com/nivram913/autosave_gd).
+Google Drive synchronization tool.
 
 Files are encrypted with AES 256 bits in CBC mode before being uploaded to Google Drive. Filenames are encrypted too.
 
@@ -12,18 +12,18 @@ The syncronization is pretty basic : it's based on modification time.
 - `openssl >= 1.1.1` (for encryption)
 - `zenity` command (for GUI)
 - `gio` utility (for emblem on synced files and file transfert to/from Google Drive)
-- `secret-tool` utility (for storing password in Gnome Keyring)
 
 *Optional :*
 
 - `thunar` file manager (for actions from right click on files)
 - `inotifywait` utility (for `gds_inotify.sh` for real time emblem updating)
 - `xfce4-genmon-plugin` plugin (for icon in Xfce panel with `gds_genmon.sh`)
+- `secret-tool` utility (for storing password in Gnome Keyring)
 
 ## Install
 
 - Place the script in a directory included in your `$PATH` (like `$HOME/bin`)
-- Configure variables `GDS_INDEX_FILE`, `REMOTE_DIR` and so on, at the beginning of the script
+- Configure variables `GD_URI`, `GDS_INDEX_FILE`, `REMOTE_DIR` and so on, at the beginning of the script
 - Create remote directory configured previously on Google Drive and place an empty `mtime.lst` file in that remote directory
 - Configure your Google Account with `gnome-control-center`
 

--- a/README.md
+++ b/README.md
@@ -58,5 +58,3 @@ Usage: ./gdsync.sh <option> [<absolute path to files>]
 --force-push  Force pushing of specified file(s)
 ```
 
-Files are never removed from server but a lot of files can be placed in trash folder of Google Drive.
-

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This tool is intended to be used from a GUI on **Xubuntu 20.04** but can run on 
 The syncronization is pretty basic : it's based on modification time.
 
 ## Requierements
-- `drive` (https://github.com/odeke-em/drive) (for Google Drive uploading)
+- `gnome-online-accounts` (for Google Drive uploading)
 - `openssl >= 1.1.1` (for encryption)
 - `zenity` command (for GUI)
-- `gio` utility (for emblem on synced files)
+- `gio` utility (for emblem on synced files and file transfert to/from Google Drive)
 - `secret-tool` utility (for storing password in Gnome Keyring)
 
 *Optional :*
@@ -25,7 +25,7 @@ The syncronization is pretty basic : it's based on modification time.
 - Place the script in a directory included in your `$PATH` (like `$HOME/bin`)
 - Configure variables `GDS_INDEX_FILE`, `REMOTE_DIR` and so on, at the beginning of the script
 - Create remote directory configured previously on Google Drive and place an empty `mtime.lst` file in that remote directory
-- Configure `drive` with `drive init` in the relevant directory (refer to the `drive`'s doc)
+- Configure your Google Account with `gnome-control-center`
 
 
 *Action from right click setup in Thunar* :

--- a/gdsync.sh
+++ b/gdsync.sh
@@ -95,7 +95,7 @@ save_remote_mtime()
 {
     local mtime_file
     
-    gio trash "$GD_URI/$REMOTE_DIR/mtime.lst"
+    gio remove "$GD_URI/$REMOTE_DIR/mtime.lst"
     
     mtime_file="$(for file in "${!REMOTE_MTIME[@]}"; do echo "${REMOTE_ENCRYPTED_NAMES["$file"]}$file/${REMOTE_MTIME["$file"]}"; done)"
     echo "$mtime_file" | push_file "$REMOTE_DIR/mtime.lst"
@@ -281,7 +281,7 @@ gds_sync()
             gio set "$file" -t stringv metadata::emblems emblem-colors-green
         elif test "${LOCAL_MTIME["$file"]}" -gt "${REMOTE_MTIME["$file"]}"
         then
-            gio trash "$GD_URI/$REMOTE_DIR/${REMOTE_ENCRYPTED_NAMES["$file"]}"
+            gio remove "$GD_URI/$REMOTE_DIR/${REMOTE_ENCRYPTED_NAMES["$file"]}"
             cat "$file" | push_file "$REMOTE_DIR/${REMOTE_ENCRYPTED_NAMES["$file"]}"
             if ((PIPESTATUS[1] > 0))
             then
@@ -489,7 +489,7 @@ gds_force_push()
         
         if test -f "$file"
         then
-            gio trash "$GD_URI/$REMOTE_DIR/${REMOTE_ENCRYPTED_NAMES["$file"]}"
+            gio remove "$GD_URI/$REMOTE_DIR/${REMOTE_ENCRYPTED_NAMES["$file"]}"
             cat "$file" | push_file "$REMOTE_DIR/${REMOTE_ENCRYPTED_NAMES["$file"]}"
             if ((PIPESTATUS[1] > 0))
             then
@@ -548,7 +548,7 @@ gds_rdel()
         ((i++))
         
         echo "$file"
-        gio trash "$GD_URI/$REMOTE_DIR/${REMOTE_ENCRYPTED_NAMES["$file"]}"
+        gio remove "$GD_URI/$REMOTE_DIR/${REMOTE_ENCRYPTED_NAMES["$file"]}"
         
         unset REMOTE_MTIME["$file"]
         REMOTE_UPDATED=true


### PR DESCRIPTION
Since `drive` authentication is deprecated by Google, now we use `gnome-online-accounts` instead.